### PR TITLE
fix(plugin): ensure shadow @property initializers are always emitted

### DIFF
--- a/.changeset/fix-shadow-property-initializers.md
+++ b/.changeset/fix-shadow-property-initializers.md
@@ -1,0 +1,9 @@
+---
+'tailwindcss-neumorphism-ui': patch
+---
+
+Fix `nm-protrude` and `nm-dent` being invisible on pages with no native shadow or ring utilities.
+
+Tailwind only emits `@property` declarations for its shadow composition variables (`--tw-shadow`, `--tw-inset-shadow`, `--tw-ring-shadow`, `--tw-inset-ring-shadow`, `--tw-ring-offset-shadow`) when at least one native shadow or ring utility is included in the build. Without those declarations, `var(--tw-shadow)` resolves as an invalid value and `box-shadow` falls back to `none`, making neumorphism effects invisible.
+
+Adding `@source inline("shadow-none")` to the plugin CSS ensures these `@property` initializers are always emitted, regardless of whether the user's project uses any other shadow utilities.

--- a/packages/tailwindcss-neumorphism-ui/src/index.css
+++ b/packages/tailwindcss-neumorphism-ui/src/index.css
@@ -1,3 +1,15 @@
+/*
+  Ensure Tailwind registers @property for all shadow composition variables
+  (--tw-shadow, --tw-inset-shadow, --tw-ring-shadow, --tw-inset-ring-shadow,
+  --tw-ring-offset-shadow) with inherits: false and initial-value: 0 0 #0000.
+
+  Tailwind only emits these @property declarations when at least one native
+  shadow utility is included in the build. Without them, var(--tw-shadow) and
+  friends resolve to an invalid value and box-shadow falls back to none,
+  making nm-protrude / nm-dent invisible on pages with no other shadow classes.
+*/
+@source inline("shadow-none");
+
 /* Light source direction values for nm-light-source-* utilities */
 @theme {
   --nm-light-source-t: 0deg;


### PR DESCRIPTION
## Summary

Fixes #36 — `nm-protrude` and `nm-dent` are invisible on pages with no native shadow or ring utility classes.

### Root cause

Tailwind v4 only emits `@property` declarations for its shadow composition variables (`--tw-shadow`, `--tw-inset-shadow`, `--tw-ring-shadow`, `--tw-inset-ring-shadow`, `--tw-ring-offset-shadow`) when at least one native shadow or ring utility is included in the build. Without those declarations, `var(--tw-shadow)` (and friends) resolve as invalid CSS values, causing the entire `box-shadow` declaration to fall back to `none` — making neumorphism effects invisible.

This happens silently with `@tailwindcss/vite` (Lightning CSS pipeline): no warnings, just blank elements.

### Fix

Add `@source inline("shadow-none")` to the plugin's own CSS file. This forces Tailwind to generate the `shadow-none` utility, which calls Tailwind's internal shadow defaults function and triggers emission of all five `@property` declarations — regardless of whether the user's project uses any other shadow classes.

This is a plugin-side fix: zero user action required. It uses Tailwind's documented `@source inline(...)` mechanism (intended for exactly this use case in plugins and libraries).

## Test plan

- [ ] All existing unit tests pass (`pnpm vitest run` in `packages/tailwindcss-neumorphism-ui`)
- [ ] Verified manually with a clean React + Vite project (`@tailwindcss/vite`) that has no other shadow/ring classes — `nm-protrude` and `nm-dent` render correctly before and after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)