### PR TITLE
chore(ci): upgrade actions to node24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,15 +20,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
         env:
@@ -42,7 +42,7 @@ jobs:
 
       - name: Create Version PR or Publish to NPM
         id: changesets
-        uses: changesets/action@v1.4.7
+        uses: changesets/action@v1.9.0
         with:
           commit: 'chore(release): version packages'
           title: 'chore(release): version packages'

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -16,13 +16,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v4 → v7, `pnpm/action-setup` v4 → v6, and `actions/setup-node` v4 → v7 across all three workflows
- Bump `changesets/action` v1.4.7 → v1.9.0 in release.yml (its Node 24 runtime upgrade landed in v1.6.0)

These versions target `node24` in their `action.yml`, which silences the "Node 20 is being deprecated" warning GitHub Actions now prints on every run. Verified via each action's changelog that there are no breaking changes affecting our usage.

## Test plan
- [ ] CI run on this PR is green and no longer shows the Node 20 deprecation warning